### PR TITLE
Allow custom DOM attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,17 +17,21 @@ Include [`dist/medium-zoom.element.js`](dist/medium-zoom.element.js) in your HTM
 ></medium-zoom>
 ```
 
-## Attributes
+## Options
 
-| Attribute         | Description                                                       |
-|-------------------|-------------------------------------------------------------------|
-| margin            | Space outside the zoomed image                                    |
-| background        | Color of the overlay                                              |
-| scroll-offset     | Number of pixels to scroll to dismiss the zoom                    |
-| disable-metaclick | Disables the action on meta click (opens the link / image source) |
-| zoom-target       | Specifies the high definition image to show on zoom               |
+| Attribute           | Description                                                       |
+|---------------------|-------------------------------------------------------------------|
+| `src`               | Source of the image                                               |
+| `alt`               | Alternative text for the image                                    |
+| `width`             | Width of the image                                                |
+| `height`            | Height of the image                                               |
+| `margin`            | Space outside the zoomed image                                    |
+| `background`        | Color of the overlay                                              |
+| `scroll-offset`     | Number of pixels to scroll to dismiss the zoom                    |
+| `disable-metaclick` | Disables the action on meta click (opens the link / image source) |
+| `zoom-target`       | Source of zoomed image                                            |
 
-Refer to [`medium-zoom > Options`](https://github.com/francoischalifour/medium-zoom#options) for default values.
+Refer to [`medium-zoom`'s options](https://github.com/francoischalifour/medium-zoom#options) for default values.
 
 ```html
 <medium-zoom
@@ -43,7 +47,7 @@ Refer to [`medium-zoom > Options`](https://github.com/francoischalifour/medium-z
 
 ## Methods
 
-Refer to [`medium-zoom > Methods`](https://github.com/francoischalifour/medium-zoom#methods).
+Refer to [`medium-zoom`'s methods](https://github.com/francoischalifour/medium-zoom#methods).
 
 ## Dev
 

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ export default class MediumZoom extends HTMLElement {
   }
 
   static get observedAttributes() {
-    return [...MediumZoom.optionAttributes, 'width', 'height']
+    return [...MediumZoom.optionAttributes, 'src', 'alt', 'width', 'height']
   }
 
   static getOptionName(value) {

--- a/index.js
+++ b/index.js
@@ -31,7 +31,14 @@ export default class MediumZoom extends HTMLElement {
   }
 
   static get observedAttributes() {
-    return [...MediumZoom.optionAttributes, 'src', 'alt', 'width', 'height']
+    return [
+      ...MediumZoom.optionAttributes,
+      'src',
+      'alt',
+      'width',
+      'height',
+      'style'
+    ]
   }
 
   static getOptionName(value) {

--- a/index.js
+++ b/index.js
@@ -6,6 +6,12 @@ const camelCased = string =>
 const template = document.createElement('template')
 template.innerHTML = `
 <style>
+  :host {
+    display: block;
+  }
+  img {
+    max-width: 100%;
+  }
   .medium-zoom-image {
     cursor: zoom-in;
   }


### PR DESCRIPTION
Replicate unknown DOM attributes to the child `img`.

```html
<medium-zoom
  src="image-1.jpg"
  alt="Image 1"
  custom-attribute=""
></medium-zoom>
```

will propagate the `custom-attribute` to the image.