### PR TITLE
Set medium-zoom as peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,17 +30,20 @@
 
 ## Usage
 
+`medium-zoom-element` requires a peer of [`medium-zoom`](https://github.com/francoischalifour/medium-zoom).
+
 From [npm](https://www.npmjs.com) or [Yarn](https://yarnpkg.com):
 
 ```sh
-npm install --save medium-zoom-element
+npm install --save medium-zoom medium-zoom-element
 # or
-yarn add medium-zoom-element
+yarn add medium-zoom medium-zoom-element
 ```
 
 From a [CDN](https://en.wikipedia.org/wiki/Content_delivery_network):
 
 ```html
+<script src="https://unpkg.com/medium-zoom@0/dist/medium-zoom.min.js"></script>
 <script src="https://unpkg.com/medium-zoom-element@0/dist/medium-zoom-element.min.js"></script>
 ```
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -180,7 +180,8 @@
       <p><a href="#">Back to top</a></p>
     </footer>
 
-    <script src="../dist/medium-zoom-element.min.js"></script>
+    <script src="https://unpkg.com/medium-zoom@0/dist/medium-zoom.min.js"></script>
+    <script src="../dist/medium-zoom-element.js"></script>
     <script>
       (function() {
         // Trigger dynamic behaviors

--- a/examples/index.html
+++ b/examples/index.html
@@ -181,7 +181,7 @@
     </footer>
 
     <script src="https://unpkg.com/medium-zoom@0/dist/medium-zoom.min.js"></script>
-    <script src="../dist/medium-zoom-element.js"></script>
+    <script src="../dist/medium-zoom-element.min.js"></script>
     <script>
       (function() {
         // Trigger dynamic behaviors

--- a/index.js
+++ b/index.js
@@ -1,5 +1,12 @@
 import mediumZoom from 'medium-zoom'
 
+if (window && !window.mediumZoom) {
+  throw new Error(
+    'medium-zoom-element requires a peer of medium-zoom.\n' +
+      'See: https://github.com/francoischalifour/medium-zoom-element'
+  )
+}
+
 const camelCased = string =>
   string.replace(/-([a-z])/g, g => g[1].toUpperCase())
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dev": "rollup --config --watch",
     "prettier": "prettier --write './*.js'"
   },
-  "dependencies": {
+  "peerDependencies": {
     "medium-zoom": "^0.2.0"
   },
   "devDependencies": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -50,6 +50,8 @@ export default [
     format: 'umd',
     name: 'MediumZoomElement'
   },
+  external: ['medium-zoom'],
+  globals: { 'medium-zoom': 'mediumZoom' },
   banner,
   plugins
 }))


### PR DESCRIPTION
Until now, `medium-zoom` was set as a dependency, meaning it would get compiled and bundled every time in the [`medium-zoom-element` bundle](https://github.com/francoischalifour/medium-zoom-element/blob/master/dist/medium-zoom-element.js). This PR sets `medium-zoom` as a peer dependency.

### Advantages

* Reduce the bundle size
* Prevent from including [`medium-zoom`](https://github.com/francoischalifour/medium-zoom) multiple times

### Disadvantages

* Include 2 scripts

---

Which solution is the most suitable for web components?